### PR TITLE
Add port env in dockercompose

### DIFF
--- a/bin/startAll.sh
+++ b/bin/startAll.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+sudo docker-compose up -d --build

--- a/bin/startMongo.sh
+++ b/bin/startMongo.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+sudo docker run \
+--name mongodb \
+-d -p 27017:27017 \
+-e MONGO_INITDB_ROOT_USERNAME=admin \
+-e MONGO_INITDB_ROOT_PASSWORD=admin \
+mongo

--- a/bin/stopAll.sh
+++ b/bin/stopAll.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+sudo docker-compose stop

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,12 +5,8 @@ services:
     network_mode: "host"
     depends_on:
       - mongodb
-    environment:
-      MONGODB_URI: ${MONGODB_URI}
-      MONGODB_USERNAME: ${MONGODB_USERNAME}
-      MONGODB_PASSWORD: ${MONGODB_PASSWORD}
-      COOKIE_SECRET: ${COOKIE_SECRET}
-      JWT_SECRET: ${JWT_SECRET}
+    env_file:
+      - .env
   mongodb:
     image: mongo:latest
     environment:


### PR DESCRIPTION
This fixes #51 

docker-compose.yaml now uses the .env file, so also gets the port environment variable.

Added scripts to start / stop docker containers